### PR TITLE
Fix parsing of access control list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+    - "3.5"
+    - "3.6"
+install: pip install tox-travis
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pylint, py35, py36
+envlist = pylint-py35, py35, py36
 
 [testenv]
 passenv = HOME
@@ -9,7 +9,7 @@ commands =
     pipenv install --dev
     pipenv run py.test {posargs}
 
-[testenv:pylint]
+[testenv:pylint-py35]
 passenv = HOME
 basepython = python3.5
 deps = {[testenv]deps}

--- a/zoho_reports/core/admin.py
+++ b/zoho_reports/core/admin.py
@@ -23,5 +23,6 @@ admin.site.register(User, CustomUserAdmin)
 
 class PageAdmin(admin.ModelAdmin):
     """Admin configuration for the Page model."""
+    list_display = ('path', '_allowed_emails')
 
 admin.site.register(Page, PageAdmin)

--- a/zoho_reports/core/models.py
+++ b/zoho_reports/core/models.py
@@ -53,11 +53,11 @@ class Page(models.Model):
     @property
     def allowed_emails(self):
         "The allowed email addresses as a list"
-        return [email.strip() for email in self._allowed_emails.split()]
+        return [email.strip().lower() for email in self._allowed_emails.split(",")]
 
     def has_access(self, user):
         """Return a bool indicating whether the given Django user has access to the page."""
         return user is not None and (
             user.is_staff or
-            user.email in self.allowed_emails
+            user.email.lower() in self.allowed_emails
         )

--- a/zoho_reports/core/models.py
+++ b/zoho_reports/core/models.py
@@ -61,3 +61,6 @@ class Page(models.Model):
             user.is_staff or
             user.email.lower() in self.allowed_emails
         )
+
+    def __str__(self):
+        return "Page at /{}/".format(self.path)

--- a/zoho_reports/core/test_models.py
+++ b/zoho_reports/core/test_models.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django_dynamic_fixture import G
 from social_django.models import UserSocialAuth
 
-from zoho_reports.core.models import User
+from zoho_reports.core.models import Page, User
 
 
 # pylint: disable=no-member
@@ -45,3 +45,22 @@ class UserTests(TestCase):
         full_name = 'Bob'
         user = G(User, full_name=full_name)
         self.assertEqual(str(user), full_name)
+
+
+class PageTest(TestCase):
+    """Tests for the Page model."""
+
+    def test_allowed_emails(self):
+        """Test the allowed_emails property."""
+        page = G(Page, _allowed_emails="audit@example.com, Student@example.com ")
+        self.assertEqual(page.allowed_emails, ["audit@example.com", "student@example.com"])
+
+    def test_has_access(self):
+        """Test that access permissions work as intended."""
+        page = G(Page, _allowed_emails="audit@example.com, Student@example.com ")
+        audit_user = G(User, is_staff=False, email="audit@Example.com")
+        user = G(User, is_staff=False)
+        staff_user = G(User, is_staff=True)
+        self.assertTrue(page.has_access(audit_user))
+        self.assertFalse(page.has_access(user))
+        self.assertTrue(page.has_access(staff_user))


### PR DESCRIPTION
The help string for the `allowed_emails` field claimed the field is comma-separated, but the code parsed it as whitespace-separated.  This PR fixes the issue by changing the code, and adds tests for that part of the code.