### PR TITLE
[BB-2909] Allow specifying `Authorization` header for OAuth2 authentication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(
     name='zoho-reports',
 
-    version='0.0.2',
+    version='0.0.3',
 
     description='Simple wrapper app for embedding Zoho reports',
 

--- a/zoho_reports/core/backends.py
+++ b/zoho_reports/core/backends.py
@@ -1,0 +1,21 @@
+"""Custom edX OAuth2 backend."""
+
+from auth_backends.backends import EdXOAuth2
+from django.conf import settings
+
+
+# pylint: disable=abstract-method
+class CustomHeaderEdXOAuth2(EdXOAuth2):
+    """This subclass allows adding the `Authorization` header to the access token request."""
+
+    def auth_headers(self):
+        """
+        Allows adding the `Authorization` header by specifying
+        `SOCIAL_AUTH_EDX_OAUTH2_AUTHORIZATION_HEADER` in settings.
+        """
+        headers = super().auth_headers()
+        print(headers)
+        if (auth_header := settings.SOCIAL_AUTH_EDX_OAUTH2_AUTHORIZATION_HEADER) is not None:
+            headers['Authorization'] = auth_header
+
+        return headers

--- a/zoho_reports/settings/base.py
+++ b/zoho_reports/settings/base.py
@@ -141,7 +141,7 @@ LOGOUT_URL = '/logout/'
 AUTH_USER_MODEL = 'core.User'
 
 AUTHENTICATION_BACKENDS = (
-    'auth_backends.backends.EdXOAuth2',
+    'zoho_reports.core.backends.CustomHeaderEdXOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 )
 
@@ -152,6 +152,10 @@ SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
 
 # Redirect to the main view after login, which will in turn redirect to a useful page.
 LOGIN_REDIRECT_URL = '/'
+
+# HACK: allows customizing `Authorization` header sent to the `/oauth2/access_token` endpoint
+#  of the edx-platform.
+SOCIAL_AUTH_EDX_OAUTH2_AUTHORIZATION_HEADER = None
 # END AUTHENTICATION CONFIGURATION
 
 

--- a/zoho_reports/settings/local.py
+++ b/zoho_reports/settings/local.py
@@ -12,3 +12,10 @@ SOCIAL_AUTH_EDX_OAUTH2_KEY = "zoho_reports"
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = "open_secret"
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "http://localhost:18000"
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "http://localhost:18000"
+# HACK: This is set locally to simulate the scenario when we have an Oauth2 application
+#  with the following parameters:
+#   - client_id: username
+#   - client_secret password
+#   - client_type: Public
+#   - grant_type: Resource owner password-based
+SOCIAL_AUTH_EDX_OAUTH2_AUTHORIZATION_HEADER = 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='

--- a/zoho_reports/settings/production.py
+++ b/zoho_reports/settings/production.py
@@ -12,6 +12,7 @@ SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get("EDX_OAUTH2_KEY", "")
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get("EDX_OAUTH2_SECRET", "")
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = os.environ.get("EDX_OAUTH2_URL_ROOT", "")
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get("EDX_OAUTH2_PUBLIC_URL_ROOT", "")
+SOCIAL_AUTH_EDX_OAUTH2_AUTHORIZATION_HEADER = os.environ.get("EDX_OAUTH2_AUTHORIZATION_HEADER", "")
 
 # Update database settings from the environment variable DATABASE_URL.
 DATABASES['default'].update(dj_database_url.config())


### PR DESCRIPTION
This adds option to specify the `Authorization` header for OAuth2 authentication by subclassing the `EdXOAuth2` backend and overriding the `auth_headers` method from `social-core`.

**Testing instructions**:
1. Start Juniper devstack.
1. Navigate to http://localhost:18000/admin/oauth2_provider/application/add/ to add a new OAuth2 client.  Use these settings:
   - Client id: username
   - Client type: Public
   - Authorization grant type: Resource owner password-based
   - Client secret: password
   - Name: Basic Auth
1. Navigate to http://localhost:18000/admin/oauth2_provider/application/add/ to add a new OAuth2 client.  Use these settings:
   - Client id: zoho_reports
   - Redirect uris: http://localhost:9000/complete/edx-oauth2/
   - Client type: Confidential
   - Authorization grant type: Authorization code
   - Client secret: open_secret
   - Name: zoho_reports
1. Navigate to http://localhost:18000/admin/oauth_dispatch/applicationaccess/add/ to add access for the new Oauth2 client.  Use these settings:
   - Application: zoho_reports
   - Scopes: user_id,profile,email
1. Make sure you have `pipenv` installed (or install it with e.g. `pip3 install --user pipenv`).
1. Set up virtualenv with `pipenv install`.
1. Run migrations (this will just create SQLite3 DB, so don't worry about the setup), create superuser (with other data than `edx` account from devstack) and start the zoho_reports development server using:
   ```bash
   pipenv run python manage.py migrate
   pipenv run python manage.py createsuperuser
   pipenv run python manage.py runserver 9000
   ```
1. Go to http://localhost:9000/admin/core/page/add/ and add a page with the following data:
   - URL path: edx
   - Page source: `<html><head><title>Test page</title></head><body><b>It works!</b></body></html>`
   - Allowed users: edx@example.com
1. Log out from Django admin.
1. Navigate to http://localhost:9000/.
1. Log in with `edx@example.com` account, confirm authorization and see that it breaks.
1. Remove the last character (`=`) from `SOCIAL_AUTH_EDX_OAUTH2_AUTHORIZATION_HEADER` in `zoho_reports/settings/local.py`.
1. Navigate to http://localhost:9000/.
1. Log in with `edx@example.com` account and confirm authorization.
1. Check that the "It works!" page is loading.

**Author notes and concerns**:
- [x] Add `EDX_OAUTH2_AUTHORIZATION_HEADER` env variable to prod.

**Reviewers**
- [x] @swalladge 

